### PR TITLE
Fix some strings not being re-translated with YAT

### DIFF
--- a/CM3D2.GoogleTranslate.Plugin/Hooks/YATHook.cs
+++ b/CM3D2.GoogleTranslate.Plugin/Hooks/YATHook.cs
@@ -47,7 +47,7 @@ namespace CM3D2.AutoTranslate.Plugin.Hooks
 
             if (translation.State == TranslationState.Finished)
             {
-				args.Translation = translation.Translation;
+                args.Translation = translation.Translation;
                 return;
             }
 

--- a/CM3D2.GoogleTranslate.Plugin/Hooks/YATHook.cs
+++ b/CM3D2.GoogleTranslate.Plugin/Hooks/YATHook.cs
@@ -47,6 +47,7 @@ namespace CM3D2.AutoTranslate.Plugin.Hooks
 
             if (translation.State == TranslationState.Finished)
             {
+				args.Translation = translation.Translation;
                 return;
             }
 


### PR DESCRIPTION
Moving a fix from my old fork (the 1.2.3-YAT):

With YAT, some strings are left untranslated if encountered again after initial translation.
This PR just adds one line to YAT's hook so that if `TranslationData` is finished, the (previously) translated string is passed to YAT's event handler directly.